### PR TITLE
Fix Android 12 Service crash

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -204,7 +204,7 @@ public final class TermuxService extends Service implements SessionChangedCallba
         // PendingIntent#getActivity(): "Note that the activity will be started outside of the context of an existing
         // activity, so you must use the Intent.FLAG_ACTIVITY_NEW_TASK launch flag in the Intent":
         notifyIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, notifyIntent, 0);
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, notifyIntent, PendingIntent.FLAG_IMMUTABLE);
 
         int sessionCount = mTerminalSessions.size();
         int taskCount = mBackgroundTasks.size();

--- a/app/src/main/java/x/org/server/DummyService.java
+++ b/app/src/main/java/x/org/server/DummyService.java
@@ -74,7 +74,7 @@ public class DummyService extends Service
 			.setOngoing(true)
 			.build();
 		PendingIntent killIntent = PendingIntent.getService(this, 5, new Intent(Intent.ACTION_DELETE, null, this, DummyService.class), PendingIntent.FLAG_CANCEL_CURRENT);
-		PendingIntent showIntent = PendingIntent.getActivity(this, 0, new Intent("", null, this, MainActivity.class), PendingIntent.FLAG_CANCEL_CURRENT);
+		PendingIntent showIntent = PendingIntent.getActivity(this, 0, new Intent("", null, this, MainActivity.class), PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 		ntf.deleteIntent = killIntent;
 		RemoteViews view = new RemoteViews(getPackageName(), R.layout.notification);
 		view.setCharSequence(R.id.notificationText, "setText", getString(R.string.notification_app_is_running, getString(getApplicationInfo().labelRes)));


### PR DESCRIPTION
This PR contains a small patch that fixes the crash caused by the service pendingIntent. Hopefully this fixes #6 